### PR TITLE
Remove references to founding members

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,9 @@ toc: true
 include:
   - .well-known
 
+plugins: 
+  - jekyll-redirect-from
+  
 defaults:
   -
     scope:

--- a/membership/founding-membership.md
+++ b/membership/founding-membership.md
@@ -1,50 +1,41 @@
 # Become a member
 
-We’re currently looking for members to help shape the Foundation for Public Code’s long term future by joining us now.
+We’re currently looking for members to help shape the Foundation for Public Code’s long term future.
 
-Members are forward-thinking public organizations with a strong principled commitment to the existence of an ecosystem of public code. You’ll be willing to take co-ownership of the Foundation and be an advocate for public code.
+Members are forward-thinking public organizations with a strong commitment to the existence of an ecosystem of public code. As a member you'll help create a global community of public code empowered organizations that pool resources and collaborate in the digital transformation of modern government.
 
-We are looking for organizations that can:
+The Foundation for Public Code was set up to help public organizations develop and maintain software together. This results in higher quality services for the public that are more cost effective, with less risk and more local control.
 
-* help us validate our code certification and stewardship processes
-* provide material support to create a public code ecosystem
+Sound interesting? Find out more [about becoming a member](https://about.publiccode.net/activities/membership-growth/) and get in touch with us!
 
 ## Benefits of being a member
 
 As a member, you’ll shape the Foundation’s processes and governance.
 
-You will:
+We will help you approach your digital systems in a way that promotes effective and high quality delivery, as well as:
 
-* be one of the first to have codebases stewarded by the Foundation (reducing your future risk and maintenance costs)
-* get a seat on the board of directors
+* help you work together with other public organizations - sharing software code and learnings - to reduce cost and make investments more effective
+* set up a sustainable relationship with the market - helping different (types of) companies work together without a single point of failure (e.g. service designers with developers with system maintainers)
+* make sure you and other public members are in control of their systems so you can respond to new citizen needs, policy goals or technologies
+
+Further benefits of membership include being able to:
+
 * steer the Foundation’s pipeline towards projects you’d like to reuse
 * gain recognition as a leader of systemic digital transformation
-
-This is in addition to the regular benefits of Foundation membership. These include being able to:
-
-* invoke continuous integration auditing resources on projects in development accepted by the Foundation (increasing the security of your code)
 * demonstrate return on IT investments from higher levels of administration
-* collectively participate in a trusted Foundation procurement strategy
+* increasing the security and quality of your code through continuous auditing resources
+* access Foundation leaders and advisors for open source strategy discussions
 * learn from and share experience with other bold, innovative public organizations and leaders in the sector
-
-We also offer:
-
-* access to Foundation leaders and advisors for open source strategy discussions
-* entry to exclusive, invite-only public code leadership summits focused on technical, compliance, and business topics
-* prominent placement of your organization’s brand on the Foundation’s social networks and web properties
-* direct access to technical decision-makers of the Foundation platform
-* opportunities for leadership roles in Foundation initiatives
-* a blogpost announcing membership
 
 ## Membership requirements
 
-To become a member you should have some of these:
+To become a member you should be a publicly owned organization (such as a city, regional government, public library or an association of public bodies), and have some of these:
 
 * enthusiasm for public code at the most senior levels within your organisation
-* a willingness to help the Foundation test its onboarding and code auditing processes, so we can get it right
+* a willingness to help improve the Foundation onboarding and code auditing processes
 * the ability to make a significant financial commitment relative to your type and size of organization (especially if you don’t currently have a codebase available, but are invested in creating a future for public code)
 * an open source software solution that you think other public organisations will be interested in reusing
-* a development team and policy experts able to work with the Foundation to refactor and document your software and policy so that they meet the Standard for Public Code
+* a development team and policy experts able to work with the Foundation to refactor and document your software and policy so that they meet the [Standard for Public Code](https://standard.publiccode.net)
 
 ## How to join the Foundation
 

--- a/membership/founding-membership.md
+++ b/membership/founding-membership.md
@@ -23,7 +23,7 @@ Further benefits of membership include being able to:
 * steer the Foundation’s pipeline towards projects you’d like to reuse
 * gain recognition as a leader of systemic digital transformation
 * demonstrate return on IT investments from higher levels of administration
-* increasing the security and quality of your code through continuous auditing resources
+* increase the security and quality of your code through continuous auditing resources
 * access Foundation leaders and advisors for open source strategy discussions
 * learn from and share experience with other bold, innovative public organizations and leaders in the sector
 

--- a/membership/founding-membership.md
+++ b/membership/founding-membership.md
@@ -2,9 +2,7 @@
 
 We’re currently looking for members to help shape the Foundation for Public Code’s long term future.
 
-Members are forward-thinking public organizations with a strong commitment to the existence of an ecosystem of public code. As a member you'll help create a global community of public code empowered organizations that pool resources and collaborate in the digital transformation of modern government.
-
-The Foundation for Public Code was set up to help public organizations develop and maintain software together. This results in higher quality services for the public that are more cost effective, with less risk and more local control.
+Members are forward-thinking public organizations with a strong commitment to the existence of an ecosystem of public code. As a member you'll help create a global community of public code empowered organizations that pool resources and collaborate in the digital transformation of modern government. This results in higher quality services for the public that are more cost effective, with less risk and more local control.
 
 Sound interesting? Find out more [about becoming a member](https://about.publiccode.net/activities/membership-growth/) and get in touch with us!
 
@@ -33,8 +31,8 @@ To become a member you should be a publicly owned organization (such as a city, 
 
 * enthusiasm for public code at the most senior levels within your organisation
 * a willingness to help improve the Foundation onboarding and code auditing processes
-* the ability to make a significant financial commitment relative to your type and size of organization (especially if you don’t currently have a codebase available, but are invested in creating a future for public code)
 * an open source software solution that you think other public organisations will be interested in reusing
+* the ability to make a significant financial commitment relative to your type and size of organization (especially if you don’t currently have a codebase available, but are invested in creating a future for public code)
 * a development team and policy experts able to work with the Foundation to refactor and document your software and policy so that they meet the [Standard for Public Code](https://standard.publiccode.net)
 
 ## How to join the Foundation

--- a/membership/founding-membership.md
+++ b/membership/founding-membership.md
@@ -1,8 +1,8 @@
-# Become a founding member
+# Become a member
 
-We’re currently looking for founding members to help shape the Foundation for Public Code’s long term future by joining us now.
+We’re currently looking for members to help shape the Foundation for Public Code’s long term future by joining us now.
 
-Founding members are forward-thinking public organizations with a strong principled commitment to the existence of an ecosystem of public code. You’ll be willing to take co-ownership of the Foundation and be an advocate for public code.
+Members are forward-thinking public organizations with a strong principled commitment to the existence of an ecosystem of public code. You’ll be willing to take co-ownership of the Foundation and be an advocate for public code.
 
 We are looking for organizations that can:
 
@@ -11,9 +11,9 @@ We are looking for organizations that can:
 
 We’ll open other types of membership from 2020.
 
-## Benefits of being a founding member
+## Benefits of being a member
 
-As a founding member, you’ll shape the Foundation’s processes and governance.
+As a member, you’ll shape the Foundation’s processes and governance.
 
 You will:
 
@@ -38,15 +38,11 @@ We also offer:
 * opportunities for leadership roles in Foundation initiatives
 * a blogpost announcing membership
 
-## Founding membership requirements
+## Membership requirements
 
-To become a founding member you should have both of these:
+To become a member you should have some of these:
 
 * enthusiasm for public code at the most senior levels within your organisation
-* the ability to make in-kind contributions to help us develop our processes and governance, so that they work better for your type of organisation
-
-To become a founding member you should have some of these:
-
 * a willingness to help the Foundation test its onboarding and code auditing processes, so we can get it right
 * the ability to make a significant financial commitment relative to your type and size of organization (especially if you don’t currently have a codebase available, but are invested in creating a future for public code)
 * an open source software solution that you think other public organisations will be interested in reusing
@@ -54,4 +50,4 @@ To become a founding member you should have some of these:
 
 ## How to join the Foundation
 
-If your organization is curious about founding membership, then we’d love to hear from you. Please email us at <membership@publiccode.net>.
+If your organization is curious about membership, then we’d love to hear from you. Please email us at <membership@publiccode.net>.

--- a/membership/founding-membership.md
+++ b/membership/founding-membership.md
@@ -9,8 +9,6 @@ We are looking for organizations that can:
 * help us validate our code certification and stewardship processes
 * provide material support to create a public code ecosystem
 
-We’ll open other types of membership from 2020.
-
 ## Benefits of being a member
 
 As a member, you’ll shape the Foundation’s processes and governance.

--- a/membership/index.md
+++ b/membership/index.md
@@ -1,3 +1,8 @@
+---
+redirect_from: 
+    - membership/founding-membership
+---
+
 # Become a member
 
 We’re currently looking for members to help shape the Foundation for Public Code’s long term future.
@@ -21,7 +26,7 @@ Further benefits of membership include being able to:
 * steer the Foundation’s pipeline towards projects you’d like to reuse
 * gain recognition as a leader of systemic digital transformation
 * demonstrate return on IT investments from higher levels of administration
-* increase the security and quality of your code through continuous auditing resources
+* increasing the security and quality of your code through continuous auditing resources
 * access Foundation leaders and advisors for open source strategy discussions
 * learn from and share experience with other bold, innovative public organizations and leaders in the sector
 

--- a/membership/index.md
+++ b/membership/index.md
@@ -26,7 +26,7 @@ Further benefits of membership include being able to:
 * steer the Foundation’s pipeline towards projects you’d like to reuse
 * gain recognition as a leader of systemic digital transformation
 * demonstrate return on IT investments from higher levels of administration
-* increasing the security and quality of your code through continuous auditing resources
+* increasing the quality and security of your code through codebase stewardship and additional resources
 * access Foundation leaders and advisors for open source strategy discussions
 * learn from and share experience with other bold, innovative public organizations and leaders in the sector
 

--- a/membership/index.md
+++ b/membership/index.md
@@ -26,7 +26,7 @@ Further benefits of membership include being able to:
 * steer the Foundation’s pipeline towards projects you’d like to reuse
 * gain recognition as a leader of systemic digital transformation
 * demonstrate return on IT investments from higher levels of administration
-* increasing the quality and security of your code through codebase stewardship
+* increase the quality and security of your code through codebase stewardship
 * access Foundation leaders and advisors for open source strategy discussions
 * learn from and share experience with other bold, innovative public organizations and leaders in the sector
 

--- a/membership/index.md
+++ b/membership/index.md
@@ -5,7 +5,7 @@ redirect_from:
 
 # Become a member
 
-We’re currently looking for members to help shape the Foundation for Public Code’s long term future.
+We’re looking for members to help shape the Foundation for Public Code’s long term future.
 
 Members are forward-thinking public organizations with a strong commitment to the existence of an ecosystem of public code. As a member you'll help create a global community of public code empowered organizations that pool resources and collaborate in the digital transformation of modern government. By benefiting from and supporting [codebase stewardship](https://publiccode.net/codebase-stewardship/), you'll help create higher quality services for the public that are more cost effective, with less risk and more local control.
 

--- a/membership/index.md
+++ b/membership/index.md
@@ -7,7 +7,7 @@ redirect_from:
 
 We’re currently looking for members to help shape the Foundation for Public Code’s long term future.
 
-Members are forward-thinking public organizations with a strong commitment to the existence of an ecosystem of public code. As a member you'll help create a global community of public code empowered organizations that pool resources and collaborate in the digital transformation of modern government. This results in higher quality services for the public that are more cost effective, with less risk and more local control.
+Members are forward-thinking public organizations with a strong commitment to the existence of an ecosystem of public code. As a member you'll help create a global community of public code empowered organizations that pool resources and collaborate in the digital transformation of modern government. By benefiting from and supporting [codebase stewardship](https://publiccode.net/codebase-stewardship/), you'll help create higher quality services for the public that are more cost effective, with less risk and more local control.
 
 Sound interesting? Find out more [about becoming a member](https://about.publiccode.net/activities/membership-growth/) and get in touch with us!
 

--- a/membership/index.md
+++ b/membership/index.md
@@ -26,7 +26,7 @@ Further benefits of membership include being able to:
 * steer the Foundation’s pipeline towards projects you’d like to reuse
 * gain recognition as a leader of systemic digital transformation
 * demonstrate return on IT investments from higher levels of administration
-* increasing the quality and security of your code through codebase stewardship and additional resources
+* increasing the quality and security of your code through codebase stewardship
 * access Foundation leaders and advisors for open source strategy discussions
 * learn from and share experience with other bold, innovative public organizations and leaders in the sector
 


### PR DESCRIPTION
Dividing members into founding members and members is no longer part of our membership model.

-----
[View rendered membership/founding-membership.md](https://github.com/publiccodenet/publiccode.net/blob/founding-members/membership/founding-membership.md)