### PR TITLE
Update OpenZaak product website URL

### DIFF
--- a/codebases/openzaak.md
+++ b/codebases/openzaak.md
@@ -46,4 +46,4 @@ OpenZaak maintainers see meeting the [Standard for Public Code](https://standard
 ## Find out more
 
 * [Github repo](https://github.com/open-zaak/open-zaak)
-* [Draft product website](https://openzaak.publiccode.net/)
+* [OpenZaak product website](https://openzaak.org/)

--- a/codebases/openzaak.md
+++ b/codebases/openzaak.md
@@ -46,4 +46,4 @@ OpenZaak maintainers see meeting the [Standard for Public Code](https://standard
 ## Find out more
 
 * [Github repo](https://github.com/open-zaak/open-zaak)
-* [OpenZaak product website](https://openzaak.org/)
+* [OpenZaak website](https://openzaak.org/)


### PR DESCRIPTION
The old URL to the draft website is now broken.

-----
[View rendered codebases/openzaak.md](https://github.com/publiccodenet/publiccode.net/blob/openzaaklink/codebases/openzaak.md)