### PR TITLE
Remove reference to us providing services from /codebase-stewardship

### DIFF
--- a/codebase-stewardship/index.html
+++ b/codebase-stewardship/index.html
@@ -74,7 +74,7 @@ title: Codebase Stewardship
   <div><h2>We take care of the product and codebase's operations and legal affairs</h2>
 
   <p>
-    To effectively steward a codebase, we provide operations support such as infrastructure and process management as well as legal services such as license support, IP management and trademark protection.
+    To effectively steward a codebase, we provide operations support such as infrastructure and process management as well as legal support such as license advice, IP management and trademark protection.
   </p>
   </div>
   <img alt="illustration, collaborative development" src="https://publiccodenet.github.io/illustrations/illustrations/collaborative-dev-2.svg">
@@ -82,7 +82,7 @@ title: Codebase Stewardship
 
 <div class="mp-section">
     <p>
-      We provide these services explicitly at <em>ecosystem level</em> – not at a national or city level – to make sure that context specific code or policy does not become a barrier to implementation.
+      We work explicitly at the <em>ecosystem level</em> – not at a national or city level – to make sure that context specific code or policy does not become a barrier to implementation.
       This means that we make sure that code is reusable across contexts globally.
     </p>
     <p>


### PR DESCRIPTION
Fixes #92.

There are no other problematic references to services on publiccode.net.