### PR TITLE
Fix path in default variables

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ plugins:
 defaults:
   -
     scope:
-      path: "team"
+      path: "who-we-are/team"
     values:
       layout: "bio"
       toc: false


### PR DESCRIPTION
The layout wasn't selected for the bio pages since the path for assigning that layout was not changed.

Jekyll documentation on Front Matter defaults: https://jekyllrb.com/docs/configuration/front-matter-defaults/