### PR TITLE
Remove Matrix configuration

### DIFF
--- a/.well-known/matrix/client
+++ b/.well-known/matrix/client
@@ -1,8 +1,0 @@
-{
-    "m.homeserver": {
-        "base_url": "https://publiccodenet.modular.im"
-    },
-    "m.identity_server": {
-        "base_url": "https://vector.im"
-    }
-}

--- a/.well-known/matrix/server
+++ b/.well-known/matrix/server
@@ -1,3 +1,0 @@
-{
-    "m.server": "publiccodenet.modular.im:443"
-}


### PR DESCRIPTION
We've tried using Riot for team and community communications
and have decided against using it.
Thus we don't need these identifiers anymore.