### PR TITLE
HTMLproofer ignore #

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -5,4 +5,8 @@ set -e # halt script on error
 bundle exec jekyll build
 
 # Check for broken links and missing alt tags, ignore edit links to GitHub as they might not exist yet
-bundle exec htmlproofer --url-ignore "/github.com/(.*)/edit/" ./_site
+
+bundle exec htmlproofer \
+    --url-ignore "/github.com/(.*)/edit/" \
+    --url-ignore "/#/" \
+    ./_site


### PR DESCRIPTION
This should unblock the Travis error on #111 (tripped by the lightbox on the codebase pages).