### PR TITLE
Adding explicit class in place of complex/unused font-size switches

### DIFF
--- a/_layouts/marketing-page.html
+++ b/_layouts/marketing-page.html
@@ -52,8 +52,11 @@ layout: site
     .mp-section img {
       max-width: 30em;
     }
-    .mp-section:not(:first-of-type) p, .mp-section:first-of-type p:first-of-type {
+    .mp-section p {
       font-size: 1.15em;
+    }
+    .mp-section p.subtext {
+      font-size: 1em;
     }
     .mp-section h1, .mp-section h2 {
       border-bottom: none;

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ title: Home
 
     <p>This results in higher quality services for the public that are more cost effective, with less risk and more local control.</p>
 
-    <p>We define ‘public code’ as open source software developed by public organizations, together with the policy and guidance needed for reuse.</p>
+    <p class="subtext">We define ‘public code’ as open source software developed by public organizations, together with the policy and guidance needed for reuse.</p>
     <p><a href="https://about.publiccode.net/CONTRIBUTING.html">Join us</a>.</p>
   </div>
 </div>
@@ -24,7 +24,7 @@ title: Home
     <p>Everything your project needs to be sustainable, collaborative and open.</p>
     <p><a href="/codebase-stewardship/">About codebase stewardship.</a></p>
   </div>
-  
+
   <svg width="100%" height="320" viewBox="0 0 420 420" style="background-color: #5B57CA" fill="none" xmlns="http://www.w3.org/2000/svg">
     <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="25" y="25" width="370" height="370">
       <circle cx="210" cy="210" r="185" fill="black"/>
@@ -81,7 +81,7 @@ title: Home
     </clipPath>
     </defs>
   </svg>
-    
+
 
 </div>
 
@@ -168,7 +168,7 @@ title: Home
     <path d="M174.899 97.1398L196.049 118.96C197.809 120.776 197.408 123.76 195.23 125.046C193.909 125.827 192.253 125.762 190.997 124.88L170.387 110.422C162.846 105.131 153.292 103.598 144.474 106.265L129.864 110.683C125.582 111.977 124.97 117.787 128.888 119.946L148.457 130.731C151.409 132.358 152.263 136.207 150.275 138.929C148.954 140.739 146.68 141.586 144.496 141.081L110.523 133.224C95.3408 129.346 81.4885 121.438 70.4298 110.337L46.4595 86.2757C37.6089 77.3914 39.5035 62.5471 50.3018 56.1705C56.9223 52.261 65.236 52.6747 71.4357 57.2221L91.2365 71.7455C99.0407 77.4698 108.114 81.2212 117.682 82.6796L159.1 88.9928C165.115 89.9096 170.664 92.7712 174.899 97.1398Z" fill="#5B57CA"/>
     <path d="M61.2287 62C61.2287 61.4477 60.781 61 60.2287 61C59.6764 61 59.2287 61.4477 59.2287 62L61.2287 62ZM59.2287 82.4574C59.2287 83.0097 59.6764 83.4574 60.2287 83.4574C60.781 83.4574 61.2287 83.0097 61.2287 82.4574L59.2287 82.4574ZM59.2287 62L59.2287 82.4574L61.2287 82.4574L61.2287 62L59.2287 62Z" fill="#F55C5C"/>
     <path d="M70.4574 73.2288C71.0097 73.2288 71.4574 72.781 71.4574 72.2288C71.4574 71.6765 71.0097 71.2288 70.4574 71.2288L70.4574 73.2288ZM50 71.2288C49.4477 71.2288 49 71.6765 49 72.2288C49 72.781 49.4477 73.2288 50 73.2288L50 71.2288ZM70.4574 71.2288L50 71.2288L50 73.2288L70.4574 73.2288L70.4574 71.2288Z" fill="#F55C5C"/>
-  </svg>    
+  </svg>
 </div>
 
 <div class="mp-section">
@@ -213,5 +213,5 @@ title: Home
     <line x1="1" y1="-1" x2="22.6041" y2="-1" transform="matrix(-0.508388 0.861128 -0.870788 -0.491659 212.934 325)" stroke="#FFF500" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     <circle cx="208.5" cy="305.5" r="8.5" fill="#FFF500"/>
     <circle cx="320" cy="374" r="4" fill="#FFF500"/>
-    </svg>    
+    </svg>
 </div>


### PR DESCRIPTION
To enlarge the "Join us" link on the index page, I'm removing some complex CSS apparently intended to universally reduce the text size of secondary paragraphs, and putting in place an explicit "subtext" class to make this smaller text size manual.

Addresses https://github.com/publiccodenet/publiccode.net/issues/136