### PR TITLE
Standardize periods after hyperlinked sentences on index

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ title: Home
     <p>This results in higher quality services for the public that are more cost effective, with less risk and more local control.</p>
 
     <p class="subtext">We define ‘public code’ as open source software developed by public organizations, together with the policy and guidance needed for reuse.</p>
-    <p><a href="https://about.publiccode.net/CONTRIBUTING.html">Join us</a>.</p>
+    <p><a href="https://about.publiccode.net/CONTRIBUTING.html">Join us</a></p>
   </div>
 </div>
 
@@ -22,7 +22,7 @@ title: Home
       </a>
     </h2>
     <p>Everything your project needs to be sustainable, collaborative and open.</p>
-    <p><a href="/codebase-stewardship/">About codebase stewardship.</a></p>
+    <p><a href="/codebase-stewardship/">About codebase stewardship</a></p>
   </div>
 
   <svg width="100%" height="320" viewBox="0 0 420 420" style="background-color: #5B57CA" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -53,7 +53,7 @@ title: Home
       </a>
     </h2>
     <p>The Standard for Public Code is a model for public organizations building open source solutions to enable successful reuse by other public organizations.</p>
-    <p><a href="https://standard.publiccode.net/">It is here for you to use.</a></p>
+    <p><a href="https://standard.publiccode.net/">It is here for you to use</a></p>
   </div>
 
   <svg width="100%" height="320" viewBox="0 0 595 421" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -93,7 +93,7 @@ title: Home
       </a>
     </h2>
     <p>This public code improves citizens' lives and experience of government every day.</p>
-    <p><a href="/codebases/">We're proud to work with these codebase communities.</a></p>
+    <p><a href="/codebases/">We're proud to work with these codebase communities</a></p>
   </div>
 
   <svg width="100%" height="320" viewBox="0 0 420 420" style="background-color: #56CCF2" fill="none"   xmlns="http://www.w3.org/2000/svg">
@@ -128,7 +128,7 @@ title: Home
       </a>
     </h2>
     <p>Public service delivery and governance depend on software, but this isn't always democratically accountable, accessible or sustainable.</p>
-    <p><a href="/background/">We exist to enable other approaches.</a></p>
+    <p><a href="/background/">We exist to enable other approaches</a></p>
   </div>
 
   <svg width="100%" height="320" viewBox="0 0 420 420" fill="none" style="background-color: #FDBBAB" xmlns="http://www.w3.org/2000/svg">
@@ -175,7 +175,7 @@ title: Home
   <div>
     <h2><a href="who-we-are/">Who we are</a></h2>
     <p>Together, we’re passionate about collaboration, open source and enabling a different way of working for public organizations. </p>
-    <p><a href="who-we-are/">Meet our experts.</a></p>
+    <p><a href="who-we-are/">Meet our experts</a></p>
   </div>
 
   <svg width="100%" height="320" viewBox="0 0 420 420" fill="none" style="background-color: #5B57CA" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Removing periods from within hyperlinked call to action sentences should make this page slightly less visually cluttered.