### PR TITLE
Narrow link check 20210201

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -4,11 +4,15 @@ set -e # halt script on error
 # Build the site
 bundle exec jekyll build
 
-# Check for broken links and missing alt tags, ignore edit links to GitHub as they might not exist yet
+# Check for broken links and missing alt tags, ignoring all links matching
+# the regular expression patterns:
+#  containing "github.com" as they might not exist yet
+#  containing "twitter.com" because twitter is broken
+#  exactly "#_" (anchored by begin of line and end of line)
+# See also:
+#  https://ruby-doc.org/core-2.7.1/Regexp.html
+#  https://github.com/gjtorikian/html-proofer/blob/main/README.md
 
 bundle exec htmlproofer \
-    --url-ignore "/github.com/(.*)/edit/" \
-    --url-ignore "/github.com/,/twitter.com/" \
-    --url-ignore "/#/" \
+    --url-ignore '/github\.com/,/twitter\.com/,/^#_$/' \
     ./_site
-    


### PR DESCRIPTION
This should narrow the matching to ignore only the lightbox links but still include links with a "#_" somewhere within, for example a link like: "example.org/docs.html#_private_method_foo"