### PR TITLE
Ruby version 2.4.0 -> 2.4.7 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.4.0
+- 2.4.7
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.


### PR DESCRIPTION
Addressing Travis failure:

zeitwerk-2.4.2 requires ruby version >= 2.4.4,
which is incompatible with the current version, ruby 2.4.0p0

https://travis-ci.com/github/publiccodenet/publiccode.net/builds/217479220

