### PR TITLE
Fix URL to match job title for communications editor job

### DIFF
--- a/careers/communications-editor.md
+++ b/careers/communications-editor.md
@@ -1,6 +1,8 @@
 ---
 type: Position
 excerpt:  Tell stories about public code's impact that everyone can understand
+redirect_from:
+/content-editor
 ---
 
 # Communications editor/storyteller

--- a/careers/communications-editor.md
+++ b/careers/communications-editor.md
@@ -2,7 +2,7 @@
 type: Position
 excerpt:  Tell stories about public code's impact that everyone can understand
 redirect_from:
-/content-editor
+    - /careers/content-editor
 ---
 
 # Communications editor/storyteller


### PR DESCRIPTION
This should help with SEO and remove any possibility for confusion re the job title.

-----
[View rendered careers/communications-editor.md](https://github.com/publiccodenet/publiccode.net/blob/fix-URL-on-communications-editor-job/careers/communications-editor.md)