### PR TITLE
Updating the Signalen explainer video link

### DIFF
--- a/codebases/signalen.html
+++ b/codebases/signalen.html
@@ -127,7 +127,7 @@ title: Codebases we work with - Signalen
     <h3>Find out more</h3>
     <ul>
       <li><a href="https://signalen.org" target="_blank">Signalen website</a></li>
-      <li><a href="https://youtube.com/watch?v=I2Z-mRFt3pg" target="_blank">"Signalen: helping cities manage and prioritize citizens' reports"</a> (video)</li>
+      <li><a href="https://youtube.com/watch?v=AdBNyYwbf8A" target="_blank">"Signalen: helping cities manage and prioritize citizens' reports"</a> (video)</li>
       <li><a href="https://github.com/Amsterdam/signals" target="_blank">Github: backend</a></li>
       <li><a href="https://github.com/Amsterdam/signals-frontend" target="_blank">Github: frontend</a></li>
       <li><a href="https://meldingen.amsterdam.nl" target="_blank">Amsterdam public interface</a></li>


### PR DESCRIPTION
Previous link seems to no longer exist. New link is to that video on Signalen's account.