### PR TITLE
Add page and redirects for former team members

### DIFF
--- a/who-we-are/former-team-members.md
+++ b/who-we-are/former-team-members.md
@@ -1,0 +1,25 @@
+---
+toc: false
+layout: default
+redirect_from:
+    - https://publiccode.net/team/alba-roza.html
+    - https://publiccode.net/who-we-are/team/alba-roza.html
+    - https://publiccode.net/team/felix-faaseen.html
+    - https://publiccode.net/who-we-are/team/felix-faaseen.html
+    - https://publiccode.net/team/laura-scheske.html
+    - https://publiccode.net/who-we-are/team/laura-scheske.html
+    - https://publiccode.net/team/deborah-meibergen.html
+    - https://publiccode.net/who-we-are/team/deborah-meibergen.html
+---
+
+# Former team members
+
+These are our former team members:
+
+* Mirjam van Tiel (2019)
+* Deborah Meibergen (2020-2021)
+* Alba Roza (2020-2021)
+* Laura Scheske (2020-2021)
+* Felix Faaseen (2020-2021)
+
+You can find [our current team here](index.md).

--- a/who-we-are/index.md
+++ b/who-we-are/index.md
@@ -72,3 +72,7 @@ Together, we're a multidisciplinary team with years of experience in government 
 </li>
 {% endfor %}
 </ul>
+
+### Former team members
+
+Our former team members can be found [in this list](former-team-members.md).


### PR DESCRIPTION
Fixes #239

-----
[View rendered who-we-are/former-team-members.md](https://github.com/publiccodenet/publiccode.net/blob/former-team-members/who-we-are/former-team-members.md)
[View rendered who-we-are/index.md](https://github.com/publiccodenet/publiccode.net/blob/former-team-members/who-we-are/index.md)