### PR TITLE
Pin html-proofer ~> 3.19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
-gem 'html-proofer'
+gem 'html-proofer', '~>3.19'
 gem "faraday", "~> 0.17"
 gem 'mdl'


### PR DESCRIPTION
fix "htmlproofer 4.0.1 | Error:  invalid option: --typhoeus-config"