### PR TITLE
Add redirects with other capitalization to OSPO.md

### DIFF
--- a/OSPO.md
+++ b/OSPO.md
@@ -2,9 +2,6 @@
 # SPDX-License-Identifier: CC0-1.0
 # SPDX-FileCopyrightText: 2022-2023 The Foundation for Public Code <info@publiccode.net>
 type: Resource
-redirect_from:
-    - /ospo
-    - /ospos
 ---
 
 # Government OSPOs: let's work together

--- a/OSPO.md
+++ b/OSPO.md
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: CC0-1.0
 # SPDX-FileCopyrightText: 2022-2023 The Foundation for Public Code <info@publiccode.net>
 type: Resource
+redirect_from:
+    - ospo
+    - ospos
+    - OSPOs
 ---
 
 # Government OSPOs: let's work together


### PR DESCRIPTION
OSPO.md was put into caps because that's grammatically correct for an abbreviation. However, most people won't expect only part of a URL to be in caps. 
Currently typing the URL with the wrong capitalization results in a 404. This PR aims to help people get to the right place.