### PR TITLE
Clarify how to certify existing codebases

### DIFF
--- a/standard-for-public-code/index.md
+++ b/standard-for-public-code/index.md
@@ -45,7 +45,7 @@ If codebases have been completely audited from the first merge request they can 
 
 If the audit process is added to an existing codebase, the new merge requests can be certified, but the existing code will not be automatically certified.
 By auditing every new merge request the codebase can move incrementally towards being completely certified.
-The codebase stewards can also do a complete audit of a codebase, at the current commit, and start applying the process from then to ensure that a codebase stays certified.
+The codebase stewards can also do a complete audit of a codebase, at the current commit, and start applying the process from then on to ensure that a codebase stays certified.
 
 ## The goals for the Standard for Public Code
 

--- a/standard-for-public-code/index.md
+++ b/standard-for-public-code/index.md
@@ -43,8 +43,9 @@ For the codebase to be completely certified every meaningful line of code, and t
 
 If codebases have been completely audited from the first merge request they can be immediately certified as compliant with the Standard for Public Code.
 
-If the audit process is added to an existing codebase, the new merge requests can be certified, but the existing code cannot be certified.
+If the audit process is added to an existing codebase, the new merge requests can be certified, but the existing code will not be automatically certified.
 By auditing every new merge request the codebase can move incrementally towards being completely certified.
+The codebase stewards can also do a complete audit of a codebase, at the current commit, and start applying the process from then to ensure that a codebase stays certified.
 
 ## The goals for the Standard for Public Code
 


### PR DESCRIPTION
I thought the "cannot" gave the wrong impression, so I expanded the section.