### PR TITLE
change type of intern position to "Closed"

### DIFF
--- a/careers/intern.md
+++ b/careers/intern.md
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: CC0-1.0
 # SPDX-FileCopyrightText: 2019-2023 The Foundation for Public Code <info@publiccode.net>
-type: Position
+type: Closed-Position
 excerpt: Not currently accepting internships.
 ---
 


### PR DESCRIPTION
This prevents the intern position from showing up in the careers index under the "Open positions" heading.