### PR TITLE
Adds contact details

### DIFF
--- a/who-we-are/index.md
+++ b/who-we-are/index.md
@@ -83,6 +83,7 @@ Together, we're a multidisciplinary team with years of experience in government 
     </a>
     <h3><a href="{{bio.url}}">{{ bio.title }}</a></h3>
     <p>{{ bio.role }}</p>
+    <p>{{ bio.email }}</p>
 </li>
 {% endfor %}
 </ul>

--- a/who-we-are/index.md
+++ b/who-we-are/index.md
@@ -82,8 +82,7 @@ Together, we're a multidisciplinary team with years of experience in government 
         </svg>
     </a>
     <h3><a href="{{bio.url}}">{{ bio.title }}</a></h3>
-    <p>{{ bio.role }}</p>
-    <p>{{ bio.email }}</p>
+    <p>{{ bio.role }} <br /> {{ bio.email }}</p>
 </li>
 {% endfor %}
 </ul>

--- a/who-we-are/team/amy-darling.md
+++ b/who-we-are/team/amy-darling.md
@@ -4,6 +4,8 @@
 type: Bio
 role: Operations, North America
 image: amy-darling.jpg
+email: amy@publiccode.net
+
 ---
 
 # Amy Darling

--- a/who-we-are/team/ben-cerveny.md
+++ b/who-we-are/team/ben-cerveny.md
@@ -4,6 +4,7 @@
 type: Bio
 role: President
 image: ben-cerveny.jpg
+email: ben@publiccode.net
 redirect_from:
     - team/ben-cerveny
 

--- a/who-we-are/team/claus-mullie.md
+++ b/who-we-are/team/claus-mullie.md
@@ -4,6 +4,7 @@
 type: Bio
 role: Coordinator codebase stewardship and community development
 image: claus-mullie.jpg
+email: claus@publiccode.net
 redirect_from:
     - team/claus-mullie
 ---

--- a/who-we-are/team/elena-findley-de-regt.md
+++ b/who-we-are/team/elena-findley-de-regt.md
@@ -4,6 +4,7 @@
 type: Bio
 role: Coordinator communications
 image: elena-findley-de-regt.jpg
+email: elena@publiccode.net
 redirect_from:
     - team/elena-findley-de-regt
 ---

--- a/who-we-are/team/eric-herman.md
+++ b/who-we-are/team/eric-herman.md
@@ -4,6 +4,7 @@
 type: Bio
 role: Lead codebase steward
 image: eric-herman.jpg
+email: eric@publiccode.net
 redirect_from:
     - team/eric-herman
 ---

--- a/who-we-are/team/jan-ainali.md
+++ b/who-we-are/team/jan-ainali.md
@@ -4,6 +4,7 @@
 type: Bio
 role: Codebase steward
 image: jan-ainali.jpg
+email: jan@publiccode.net
 redirect_from:
     - team/jan-ainali
 ---

--- a/who-we-are/team/kehinde-bademosi.md
+++ b/who-we-are/team/kehinde-bademosi.md
@@ -4,6 +4,7 @@
 type: Bio
 role: Storytelling strategist
 image: kehinde-bademosi.jpg
+email: kehinde@publiccode.net
 ---
 
 # Kehinde Bademosi

--- a/who-we-are/team/matthew-claudel.md
+++ b/who-we-are/team/matthew-claudel.md
@@ -4,6 +4,7 @@
 type: Bio
 role: Strategy, North America
 image: matthew-claudel.png
+email: matthew@publiccode.net
 ---
 
 # Matthew Claudel

--- a/who-we-are/team/max-carlson.md
+++ b/who-we-are/team/max-carlson.md
@@ -4,6 +4,7 @@
 type: Bio
 role: Codebase steward, North America
 image: max-carlson.jpeg
+email: max@publiccode.net
 ---
 
 # Max Carlson


### PR DESCRIPTION
Closes #291

Thought it would be best to have the email upfront, instead of a layer deeper on the profile bio page. Feels more inviting to reach out.

In terms of layout
```
    <p>{{ bio.role }}<p>
    <p>{{ bio.email }}</p>
```
could also work, more spacious, but to me it felt a bit floaty 