### PR TITLE
test-with-link-check: ignore linkedin

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -26,6 +26,7 @@ bundle exec jekyll build
 # * docs.github.com/en : blocked by github DDoS protection
 # * plausible.io/js/plausible.js : does not serve to scripts
 # * twitter : grrr
+# * linkedin.com : "999 No error"
 # * 127.0.0.1 : localhost does not need to be checked
 # * #_$ : our special anchor
 #
@@ -34,6 +35,7 @@ URL_IGNORE_REGEXES="\
 ,/docs\.github\.com\/en\//\
 ,/plausible\.io\/js\/plausible\.js/\
 ,/twitter\.com/\
+,/linkedin\.com/\
 ,/127\.0\.0\.1:/\
 ,/^#_$/\
 "


### PR DESCRIPTION
In https://github.com/publiccodenet/publiccode.net/actions/runs/8476081170/job/23225131711 it can be seen:

```
- ./_site/who-we-are/former-team-members.html
  *  External link https://www.linkedin.com/in/albaroza/ failed: 999 No error
```

Note: 999 is _very_ wrong by linkedin, not a valid HTTP status code